### PR TITLE
Fixes assert inconclusive to rewrite as failure

### DIFF
--- a/MsTestToXunitConverter.xUnit/AssertInvocationTests.cs
+++ b/MsTestToXunitConverter.xUnit/AssertInvocationTests.cs
@@ -66,16 +66,10 @@ namespace MsTestToXunitConverter.xUnit
         [Fact]
         public async Task ConvertsAssertIsTrue() => await ExecuteAsyncInvocationTest("TestIsTrue", AssertRewriter.RewriteIsTrue);
 
+        [Fact]
+        public async Task ConvertsAssertInconclusive() => await ExecuteAsyncInvocationTest("TestInconculsive", AssertRewriter.RewriteInconclusive);
+
         [Fact(Skip = "https://xunit.github.io/docs/comparisons.html specifies this, but I don't see it and since they're the same, don't care.")]
         public void ConvertsAssertDoesNotContain() => Assert.True(false, "Method should be skipped");
-
-        [Fact]
-        public void ConvertsAssertInconclusive()
-        {
-            var actual = InvocationExpression(MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, IdentifierName("Assert"), IdentifierName("Inconclusive")));
-            actual = actual.RewriteInconclusive();
-
-            Assert.Equal("//Not supported by xunitAssert.Inconclusive()", actual.ToFullString()); //This doesn't feel good, but I wanted to try it out anyway.
-        }
     }
 }

--- a/MsTestToXunitConverter.xUnit/Resources/AssertInvocations/TestInconculsive.cs
+++ b/MsTestToXunitConverter.xUnit/Resources/AssertInvocations/TestInconculsive.cs
@@ -10,7 +10,7 @@ namespace MsTestToXunitConverter.xUnit
     {
         public void TestInconculsive()
         {
-            Assert.Inconclusive("This should get commented out");
+            Assert.Inconclusive("This used to be inconclusive. We set as failure so the user can run tests immediately.");
         }
     }
 }

--- a/MsTestToXunitConverter.xUnit/Resources/AssertInvocations/TestInconculsive.out.cs
+++ b/MsTestToXunitConverter.xUnit/Resources/AssertInvocations/TestInconculsive.out.cs
@@ -10,7 +10,7 @@ namespace MsTestToXunitConverter.xUnit
     {
         public void TestInconculsive()
         {
-            //Assert.Inconclusive("This should get commented out");
+            Assert.True(false, "This used to be inconclusive. We set as failure so the user can run tests immediately.");
         }
     }
 }


### PR DESCRIPTION
Associated with #8
@RikkiGibson convinced me that it was better to have a failure than a
build error: because it allows users to run tests faster, they can see
the failure in a diff, and because inconclusive is usually just a
failure to access some resource during integration tests (run just unit
tests).